### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /usr/src/app
+COPY package.json package.json
+RUN npm install
+COPY . .
+RUN npm run compile
+CMD ["npm", "run", "compile"]

--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ This VS Code extension provides a simple interface to OpenAI's chat completions 
 3. Launch the extension in the Extension Development Host.
 
 In coding mode the extension reads all files under the first workspace folder (up to 50 KB each) and sends their contents along with your prompt.
+## Docker
+
+You can build and run the extension in a Docker container. This allows running tests or compilation in any environment without installing Node.js locally.
+
+```bash
+# Build the container
+docker build -t vscode-gpt .
+
+# Run tests (or compile) inside the container
+docker run --rm vscode-gpt
+```
+


### PR DESCRIPTION
## Summary
- add Dockerfile and `.dockerignore` so the extension can be built anywhere
- document Docker usage in README

## Testing
- `npm install`
- `npm run compile`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68809b558c20832495356a4d6649bb41